### PR TITLE
Extract hostnames from interactions

### DIFF
--- a/src/main/java/burp/BurpExtender.java
+++ b/src/main/java/burp/BurpExtender.java
@@ -17,6 +17,7 @@ import java.awt.event.*;
 import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.*;
 import java.util.*;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -245,7 +246,7 @@ public class BurpExtender implements IBurpExtender, ITab, IExtensionStateListene
                 model.addColumn("Time");
                 model.addColumn("Type");
                 model.addColumn("IP");
-                model.addColumn("Payload");
+                model.addColumn("Hostname");
                 model.addColumn("Comment");
                 collaboratorTable.getColumnModel().getColumn(0).setPreferredWidth(50);
                 collaboratorTable.getColumnModel().getColumn(0).setMaxWidth(50);
@@ -342,7 +343,7 @@ public class BurpExtender implements IBurpExtender, ITab, IExtensionStateListene
                                 interactionsTab.addTab("Description", descriptionPanel);
                                 if(interaction.get("type").equals("DNS")) {
                                     TaboratorMessageEditorController taboratorMessageEditorController = new TaboratorMessageEditorController();
-                                    description.setText("The Collaborator server received a DNS lookup of type " + interaction.get("query_type") + " for the domain name " + interaction.get("interaction_id") + "." + collaborator.getCollaboratorServerLocation() + ".\n\n" +
+                                    description.setText("The Collaborator server received a DNS lookup of type " + interaction.get("query_type") + " for the hostname " + interaction.get("hostname") + "\n\n" +
                                             "The lookup was received from IP address " + interaction.get("client_ip") + " at " + interaction.get("time_stamp"));
                                     IMessageEditor messageEditor = callbacks.createMessageEditor(taboratorMessageEditorController, false);
                                     messageEditor.setMessage(helpers.base64Decode(interaction.get("raw_query")), false);
@@ -429,7 +430,7 @@ public class BurpExtender implements IBurpExtender, ITab, IExtensionStateListene
                                     byte[] collaboratorRequest = helpers.base64Decode(interaction.get("request"));
                                     taboratorMessageEditorController.setRequest(collaboratorRequest);
                                     taboratorMessageEditorController.setResponse(collaboratorResponse);
-                                    description.setText("The Collaborator server received an "+interaction.get("protocol")+" request.\n\nThe request was received from IP address "+interaction.get("client_ip")+" at "+interaction.get("time_stamp"));
+                                    description.setText("The Collaborator server received an "+interaction.get("protocol")+" request.\n\nThe request was received from IP address "+interaction.get("client_ip")+" at "+interaction.get("time_stamp") + " for the hostname " + interaction.get("hostname"));
                                     if(originalRequests.containsKey(interaction.get("interaction_id"))) {
                                         HashMap<String, String> requestInfo = originalRequests.get(interaction.get("interaction_id"));
                                         IHttpService httpService = helpers.buildHttpService(requestInfo.get("host"), Integer.decode(requestInfo.get("port")), requestInfo.get("protocol"));
@@ -550,7 +551,7 @@ public class BurpExtender implements IBurpExtender, ITab, IExtensionStateListene
         });
     }
     private void insertInteraction(HashMap<String,String> interaction, int rowID) {
-        model.addRow(new Object[]{rowID,interaction.get("time_stamp"), interaction.get("type"), interaction.get("client_ip"), interaction.get("interaction_id"), ""});
+        model.addRow(new Object[]{rowID,interaction.get("time_stamp"), interaction.get("type"), interaction.get("client_ip"), interaction.get("hostname"), ""});
         if(comments.size() > 0) {
             int actualID = getRealRowID(rowID);
             if(actualID > -1 && comments.containsKey(actualID)) {
@@ -651,6 +652,7 @@ public class BurpExtender implements IBurpExtender, ITab, IExtensionStateListene
             for (Map.Entry<String,String> interactionData : interaction.getProperties().entrySet()) {
                 interactionHistoryItem.put(interactionData.getKey(), interactionData.getValue());
             }
+            interactionHistoryItem.put("hostname", getHostnameFromInteraction(interactionHistoryItem));
             insertInteraction(interactionHistoryItem, rowID);
             unread++;
             interactionHistory.put(rowID, interactionHistoryItem);
@@ -880,6 +882,112 @@ public class BurpExtender implements IBurpExtender, ITab, IExtensionStateListene
         }
 
         return matches;
+    }
+
+    private String getHostnameFromInteraction(HashMap<String, String> interaction) {
+        String fallback = interaction.get("interaction_id") + "." + collaborator.getCollaboratorServerLocation();
+        switch(interaction.get("type")) {
+            case "DNS":
+                return getHostnameFromDnsRequest(helpers.base64Decode(interaction.get("raw_query")), fallback);
+            case "HTTP":
+                return getHostnameFromHttpRequest(helpers.bytesToString(helpers.base64Decode(interaction.get("request"))), fallback);
+            case "SMTP":
+                return getHostnameFromSmtpConversation(helpers.bytesToString(helpers.base64Decode(interaction.get("conversation"))), fallback);
+            default:
+                return fallback;
+        }
+    }
+
+    private static String getHostnameFromDnsRequest(byte[] rawQuery, String fallback) {
+        StringBuilder hostname = new StringBuilder();
+        HashSet<Integer> seenPtrs = new HashSet<Integer>();
+
+        ByteBuffer bb = ByteBuffer.wrap(rawQuery);
+
+        // Seek to QDCOUNT
+        bb.position(4);
+
+        // If there is a number of questions other than 1 in the query, something has gone wrong
+        short num_questions = bb.getShort();
+        if (num_questions != 1) {
+            return fallback;
+        }
+
+        // Seek to Question section
+        bb.position(12);
+
+        // Read hostname
+        try {
+            while (true) {
+                int token_len = bb.get();
+
+                if (token_len == 0) {
+                    // Reached the end of the hostname
+                    break;
+                }
+
+                if (token_len == 0x0c) {
+                    // Magic pointer value. See RFC1035 section 4.1.4
+                    // This isn't a correct implementation. We assume that OFFSET fits into the field's lower byte
+                    // The Burp Collaborator server doesn't seem to support pointers anyway and we don't really
+                    // expect to see pointers in DNS queries (?)
+                    int ptr = bb.get();
+                    if (seenPtrs.contains(ptr)) {
+                        // Loop detected
+                        return fallback;
+                    }
+                    seenPtrs.add(ptr);
+                    bb.position(ptr);
+                } else {
+                    // Grab the token
+                    for (int i = 0; i < token_len; i++) {
+                        hostname.append((char) bb.get());
+                    }
+                    hostname.append(".");
+                }
+            }
+        } catch (BufferUnderflowException | IllegalArgumentException e) {
+            // OOB error in the ByteBuffer.get() or .position()
+            return fallback;
+        }
+
+        if (hostname.length() == 0) {
+            return hostname.toString();
+        } else {
+            // Remove the trailing "."
+            return hostname.substring(0, hostname.length() - 1);
+        }
+    }
+
+    private static String getHostnameFromHttpRequest(String request, String fallback) {
+        String[] lines = request.split("\r\n");
+        for (String line : lines) {
+            if (line.isEmpty()) {
+                break;
+            } else if (line.toLowerCase(Locale.ROOT).startsWith("host: ")) {
+                return line.split(" ", 2)[1];
+            }
+        }
+        return fallback;
+    }
+
+    private static String getHostnameFromSmtpConversation(String conversation, String fallback) {
+        String[] lines = conversation.split("\r\n");
+        Pattern bracketedAddressPat = Pattern.compile("<(.*)>");
+        for (String line : lines) {
+            if (line.toLowerCase(Locale.ROOT).startsWith("rcpt to:")) {
+                String recipient = line.split(":", 2)[1].trim();
+                Matcher m = bracketedAddressPat.matcher(recipient);
+                if (m.find()) {
+                    // Parsing email addresses is hard but hopefully we've just found a bracketed email address
+                    // e.g. <peter@example.com>
+                    recipient = m.group(1).trim();
+                }
+                int pos = recipient.lastIndexOf("@");
+                return recipient.substring(pos + 1);
+            }
+        }
+        return fallback;
     }
 
     public List<JMenuItem> createMenuItems(IContextMenuInvocation invocation) {


### PR DESCRIPTION
Hostnames replace the "Payload" column in the table, appear in the HTTP and DNS
Description messages, and are included in JSON exports.

Fixes https://github.com/hackvertor/taborator/issues/5

![taborator_with_hostnames](https://user-images.githubusercontent.com/1893909/109271251-60704d00-7863-11eb-9929-668862dff81a.png)

```plain
% jq . export.json
[... SNIP ...]
    "4": {                                                                                                                                                                                                          
      "hostname": "foobar.gdxmk829oqb8pay41wdf3i908reh26.burpcollaborator.net",                                                                                                                                     
      "time_stamp": "2021-Feb-26 07:43:38 UTC",                                                                                                                                                                     
      "interaction_type": "collaborator",
      "client_ip": "[... REDACTED ...]",
      "query_type": "A",
      "interaction_id": "gdxmk829oqb8pay41wdf3i908reh26",
      "type": "DNS",
      "raw_query": "+WIAEAABAAAAAAABBmZvb2Jhch5nZHhtazgyOW9xYjhwYXk0MXdkZjNpOTA4cmVoMjYQYnVycGNvbGxhYm9yYXRvcgNuZXQAAAEAAQAAKRAAAACAAAAA"
    },
    "5": {
      "request": "R0VUIC8gSFRUUC8xLjENCkhvc3Q6IGZvb2Jhci5nZHhtazgyOW9xYjhwYXk0MXdkZjNpOTA4cmVoMjYuYnVycGNvbGxhYm9yYXRvci5uZXQNClVzZXItQWdlbnQ6IHB5dGhvbi1yZXF1ZXN0cy8yLjIxLjANCkFjY2VwdC1FbmNvZGluZzogZ3ppcCwgZGVmbGF0ZQ0KQWNjZXB0OiAqLyoNCkNvbm5lY3Rpb246IGtlZXAtYWxpdmUNCg0K",
      "protocol": "HTTP",
      "hostname": "foobar.gdxmk829oqb8pay41wdf3i908reh26.burpcollaborator.net",
      "time_stamp": "2021-Feb-26 07:43:40 UTC",
      "response": "SFRUUC8xLjEgMjAwIE9LDQpTZXJ2ZXI6IEJ1cnAgQ29sbGFib3JhdG9yIGh0dHBzOi8vYnVycGNvbGxhYm9yYXRvci5uZXQvDQpYLUNvbGxhYm9yYXRvci1WZXJzaW9uOiA0DQpDb250ZW50LVR5cGU6IHRleHQvaHRtbA0KQ29udGVudC1MZW5ndGg6IDUzDQoNCjxodG1sPjxib2R5Pnl6ZWF0ZTlmYTZ1MW12azRiaXZ5YXJ6amlnejwvYm9keT48L2h0bWw+",
      "interaction_type": "collaborator",
      "client_ip": "[... REDACTED ...]",
      "interaction_id": "gdxmk829oqb8pay41wdf3i908reh26",
      "type": "HTTP"
    },

[... SNIP ...]

```

Tested using:

```python
#!/usr/bin/env python3
import requests
import sys
from smtplib import SMTP_SSL as SMTP
from email.mime.text import MIMEText

try:
    collab = sys.argv[1]
except:
    sys.exit(f"Usage: {sys.argv[0]} <collab domain>")

requests.get(f"http://foobar.{collab}")

sender = "attacker@attacker.com"

msg = MIMEText("Test message", "plain")
msg["Subject"] = "Test message"
msg["From"] = sender

conn = SMTP(f"fizzbuzz.{collab}")
conn.sendmail(sender, [f"Peter Winter <peter@fizzbuzz.{collab}"], msg.as_string())
```